### PR TITLE
Add ansible-based system fact collector and viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+results/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # AutoConfig
+
+This project demonstrates how to collect system facts from hosts using Ansible and
+render the results in a simple HTML report. The playbook gathers the list of
+system users and listening network ports, then saves the collected data as JSON.
+A Python helper script runs the playbook and generates an easy to read web page
+from the results.
+
+## Requirements
+- Python 3
+- Ansible
+- Jinja2 (installed automatically with Ansible)
+
+## Setup
+Run the provided helper script to automatically install the necessary packages:
+
+```bash
+./setup.sh
+```
+
+## Usage
+Run the helper script which will invoke the playbook and generate `results/index.html`:
+
+```bash
+python3 collect_and_visualize.py
+```
+
+Open `results/index.html` in a browser to view the collected information.

--- a/ansible/collect_facts.yml
+++ b/ansible/collect_facts.yml
@@ -1,0 +1,30 @@
+---
+- hosts: targets
+  gather_facts: yes
+  vars:
+    output_dir: "{{ lookup('env', 'OUTPUT_DIR') | default('results', true) }}"
+  tasks:
+    - name: Ensure output directory exists on controller
+      file:
+        path: "{{ output_dir }}"
+        state: directory
+      delegate_to: localhost
+
+    - name: Get user list
+      command: getent passwd
+      register: user_list
+
+    - name: Get listening ports
+      command: ss -tulwn
+      register: port_list
+
+    - name: Save facts to JSON
+      copy:
+        dest: "{{ output_dir }}/facts_{{ inventory_hostname }}.json"
+        content: |
+          {
+            "hostname": "{{ ansible_facts.hostname }}",
+            "users": {{ user_list.stdout_lines | to_json }},
+            "ports": {{ port_list.stdout_lines | to_json }}
+          }
+      delegate_to: localhost

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -1,0 +1,2 @@
+[targets]
+localhost ansible_connection=local

--- a/collect_and_visualize.py
+++ b/collect_and_visualize.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+from pathlib import Path
+from jinja2 import Template
+
+BASE_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = BASE_DIR / "results"
+
+PLAYBOOK = BASE_DIR / "ansible" / "collect_facts.yml"
+INVENTORY = BASE_DIR / "ansible" / "hosts.ini"
+
+
+def run_playbook():
+    env = os.environ.copy()
+    env["OUTPUT_DIR"] = str(RESULTS_DIR)
+    subprocess.run([
+        "ansible-playbook",
+        "-i",
+        str(INVENTORY),
+        str(PLAYBOOK)
+    ], check=True, env=env)
+
+
+def load_results():
+    hosts = []
+    for path in RESULTS_DIR.glob("facts_*.json"):
+        with open(path, "r") as f:
+            data = json.load(f)
+            hosts.append(data)
+    return hosts
+
+
+HTML_TEMPLATE = Template(
+    """
+    <html>
+    <head>
+        <meta charset='utf-8'>
+        <title>System Facts</title>
+        <style>
+            body { font-family: Arial, sans-serif; }
+            h2 { border-bottom: 1px solid #ccc; }
+            ul { list-style-type: none; padding: 0; }
+            li { margin: 0.2em 0; }
+        </style>
+    </head>
+    <body>
+    <h1>Collected System Facts</h1>
+    {% for host in hosts %}
+        <h2>{{ host.hostname }}</h2>
+        <h3>Users</h3>
+        <ul>
+        {% for user in host.users %}
+            <li>{{ user }}</li>
+        {% endfor %}
+        </ul>
+        <h3>Listening Ports</h3>
+        <ul>
+        {% for port in host.ports %}
+            <li>{{ port }}</li>
+        {% endfor %}
+        </ul>
+    {% endfor %}
+    </body>
+    </html>
+    """
+)
+
+
+def generate_html(hosts):
+    html = HTML_TEMPLATE.render(hosts=hosts)
+    output_file = RESULTS_DIR / "index.html"
+    with open(output_file, "w") as f:
+        f.write(html)
+    print(f"Report written to {output_file}")
+
+
+if __name__ == "__main__":
+    RESULTS_DIR.mkdir(exist_ok=True)
+    run_playbook()
+    hosts = load_results()
+    generate_html(hosts)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+# Simple environment setup script for local testing
+# Installs Ansible and required packages using apt if they are not already present
+
+if ! command -v ansible >/dev/null; then
+    sudo apt-get update
+    sudo apt-get install -y ansible
+fi
+
+if ! command -v ss >/dev/null; then
+    sudo apt-get install -y iproute2
+fi
+
+# Install pip and the Jinja2 package used by the helper script
+if ! command -v pip3 >/dev/null; then
+    sudo apt-get install -y python3-pip
+fi
+
+if ! python3 -c 'import jinja2' 2>/dev/null; then
+    pip3 install --break-system-packages Jinja2
+fi
+
+# Install python3 if missing (usually preinstalled)
+if ! command -v python3 >/dev/null; then
+    sudo apt-get install -y python3
+fi
+
+# Provide message about running the main script
+echo "Environment configured. You can now run: python3 collect_and_visualize.py"
+


### PR DESCRIPTION
## Summary
- add playbook to collect facts about users and listening ports
- add helper script that runs the playbook and creates an HTML report
- update README with usage instructions
- ignore generated results directory
- add script to locally configure the environment

## Testing
- `./setup.sh`
- `python3 collect_and_visualize.py`


------
https://chatgpt.com/codex/tasks/task_e_68408ea6b3a4832cabab9578efb4a159