### PR TITLE
Add React report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AutoConfig
 
-This project demonstrates how to collect system facts from hosts using Ansible and
-render the results in a simple HTML report. The playbook gathers the list of
-system users and listening network ports, then saves the collected data as JSON.
-A Python helper script runs the playbook and generates an easy to read web page
-from the results.
+This project demonstrates how to collect system facts from hosts using Ansible
+and render the results in a small React application. The playbook gathers the
+list of system users and listening network ports, then saves the collected data
+as JSON. A Python helper script runs the playbook and generates a React based
+web page that displays the results.
 
 ## Requirements
 - Python 3
@@ -19,10 +19,13 @@ Run the provided helper script to automatically install the necessary packages:
 ```
 
 ## Usage
-Run the helper script which will invoke the playbook and generate `results/index.html`:
+Run the helper script which will invoke the playbook and generate a small React
+site in the `results` directory:
 
 ```bash
 python3 collect_and_visualize.py
 ```
 
-Open `results/index.html` in a browser to view the collected information.
+Open `results/index.html` in a browser to view the collected information. The
+page will load `data.json` from the same directory and display the facts using
+React.

--- a/collect_and_visualize.py
+++ b/collect_and_visualize.py
@@ -34,10 +34,14 @@ def load_results():
 
 HTML_TEMPLATE = Template(
     """
+    <!DOCTYPE html>
     <html>
     <head>
         <meta charset='utf-8'>
         <title>System Facts</title>
+        <script crossorigin src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+        <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+        <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
         <style>
             body { font-family: Arial, sans-serif; }
             h2 { border-bottom: 1px solid #ccc; }
@@ -46,33 +50,56 @@ HTML_TEMPLATE = Template(
         </style>
     </head>
     <body>
-    <h1>Collected System Facts</h1>
-    {% for host in hosts %}
-        <h2>{{ host.hostname }}</h2>
-        <h3>Users</h3>
-        <ul>
-        {% for user in host.users %}
-            <li>{{ user }}</li>
-        {% endfor %}
-        </ul>
-        <h3>Listening Ports</h3>
-        <ul>
-        {% for port in host.ports %}
-            <li>{{ port }}</li>
-        {% endfor %}
-        </ul>
-    {% endfor %}
+        <div id="root"></div>
+        <script type="text/babel">
+        fetch('data.json')
+          .then(response => response.json())
+          .then(data => {
+            function Host({host}) {
+                return (
+                  <div>
+                    <h2>{host.hostname}</h2>
+                    <h3>Users</h3>
+                    <ul>
+                      {host.users.map((u, i) => <li key={i}>{u}</li>)}
+                    </ul>
+                    <h3>Listening Ports</h3>
+                    <ul>
+                      {host.ports.map((p, i) => <li key={i}>{p}</li>)}
+                    </ul>
+                  </div>
+                );
+            }
+
+            function App() {
+                return (
+                  <div>
+                    <h1>Collected System Facts</h1>
+                    {data.map((h, i) => <Host key={i} host={h} />)}
+                  </div>
+                );
+            }
+
+            ReactDOM.render(<App />, document.getElementById('root'));
+          });
+        </script>
     </body>
     </html>
     """
 )
 
 
-def generate_html(hosts):
-    html = HTML_TEMPLATE.render(hosts=hosts)
+def generate_site(hosts):
+    """Generate the React web site and JSON data."""
+    html = HTML_TEMPLATE.render()
     output_file = RESULTS_DIR / "index.html"
     with open(output_file, "w") as f:
         f.write(html)
+
+    data_file = RESULTS_DIR / "data.json"
+    with open(data_file, "w") as f:
+        json.dump(hosts, f, indent=2)
+
     print(f"Report written to {output_file}")
 
 
@@ -80,4 +107,4 @@ if __name__ == "__main__":
     RESULTS_DIR.mkdir(exist_ok=True)
     run_playbook()
     hosts = load_results()
-    generate_html(hosts)
+    generate_site(hosts)


### PR DESCRIPTION
## Summary
- render results using a small React app instead of plain HTML
- update the helper script to output `index.html` and `data.json`
- document the new React viewer in the README

## Testing
- `python3 -m py_compile collect_and_visualize.py`
- *(failed: `python3 collect_and_visualize.py` due to missing Jinja2)*

------
https://chatgpt.com/codex/tasks/task_e_68411e7d06e8832c9f23f82cf3db29e4