### PR TITLE
Fix YAML quoting for memory task

### DIFF
--- a/ansible/collect_facts.yml
+++ b/ansible/collect_facts.yml
@@ -19,11 +19,11 @@
       register: port_list
 
     - name: Get disk usage
-      command: df -h --output=size,used,avail,pcent / | tail -n 1
+      shell: df -h --output=size,used,avail,pcent / | tail -n 1
       register: disk_usage
 
     - name: Get memory info
-      command: free -m | grep Mem:
+      shell: free -m | grep 'Mem:'
       register: memory_info
 
     - name: Get CPU load

--- a/ansible/hosts.ini
+++ b/ansible/hosts.ini
@@ -1,2 +1,2 @@
 [targets]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3


### PR DESCRIPTION
## Summary
- quote shell command for memory info to avoid YAML colon error
- use shell module for disk usage command
- set Python interpreter in hosts file for local plays

## Testing
- `ansible-playbook -i ansible/hosts.ini ansible/collect_facts.yml --syntax-check`
- `ansible-playbook -i ansible/hosts.ini ansible/collect_facts.yml`
- `python3 scripts/collect_and_visualize.py`

------
https://chatgpt.com/codex/tasks/task_e_68412cd5d2b8832cb8f80c9fbf718b55