### PR TITLE
Fix nginx config for remote access

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,7 +1,8 @@
 events {}
 http {
     server {
-        listen {{ port }};
+        listen {{ port }} default_server;
+        listen [::]:{{ port }} default_server;
         server_name _;
         root {{ root }};
         location / {


### PR DESCRIPTION
## Summary
- listen on all addresses in the generated nginx config so it can be reached remotely

## Testing
- `python3 -m py_compile scripts/collect_and_visualize.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_68413986a74c832c84d91854fc1c7722