### PR TITLE
Use context managers for SQLite connections

### DIFF
--- a/scripts/collect_and_visualize.py
+++ b/scripts/collect_and_visualize.py
@@ -81,19 +81,17 @@ def load_results():
 
 def save_to_db(hosts):
     """Store hosts data in a small SQLite database for the API."""
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute(
-        "CREATE TABLE IF NOT EXISTS hosts (hostname TEXT PRIMARY KEY, data TEXT)"
-    )
-    cur.execute("DELETE FROM hosts")
-    for h in hosts:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
         cur.execute(
-            "INSERT OR REPLACE INTO hosts(hostname, data) VALUES(?, ?)",
-            (h.get("hostname"), json.dumps(h)),
+            "CREATE TABLE IF NOT EXISTS hosts (hostname TEXT PRIMARY KEY, data TEXT)"
         )
-    conn.commit()
-    conn.close()
+        cur.execute("DELETE FROM hosts")
+        for h in hosts:
+            cur.execute(
+                "INSERT OR REPLACE INTO hosts(hostname, data) VALUES(?, ?)",
+                (h.get("hostname"), json.dumps(h)),
+            )
 
 
 with open(HTML_TEMPLATE_PATH, "r") as f:

--- a/server.py
+++ b/server.py
@@ -13,13 +13,11 @@ app = Flask(__name__)
 
 def init_db():
     DB_PATH.parent.mkdir(exist_ok=True)
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute(
-        "CREATE TABLE IF NOT EXISTS hosts (hostname TEXT PRIMARY KEY, data TEXT)"
-    )
-    conn.commit()
-    conn.close()
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS hosts (hostname TEXT PRIMARY KEY, data TEXT)"
+        )
 
 
 def load_data():
@@ -28,30 +26,27 @@ def load_data():
             hosts = json.load(f)
     else:
         hosts = []
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute("DELETE FROM hosts")
-    for h in hosts:
-        cur.execute(
-            "INSERT OR REPLACE INTO hosts(hostname, data) VALUES(?, ?)",
-            (h.get("hostname"), json.dumps(h)),
-        )
-    conn.commit()
-    conn.close()
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("DELETE FROM hosts")
+        for h in hosts:
+            cur.execute(
+                "INSERT OR REPLACE INTO hosts(hostname, data) VALUES(?, ?)",
+                (h.get("hostname"), json.dumps(h)),
+            )
 
 
 def get_hosts(search=None):
-    conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    if search:
-        cur.execute(
-            "SELECT data FROM hosts WHERE hostname LIKE ?",
-            (f"%{search}%",),
-        )
-    else:
-        cur.execute("SELECT data FROM hosts")
-    rows = cur.fetchall()
-    conn.close()
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        if search:
+            cur.execute(
+                "SELECT data FROM hosts WHERE hostname LIKE ?",
+                (f"%{search}%",),
+            )
+        else:
+            cur.execute("SELECT data FROM hosts")
+        rows = cur.fetchall()
     return [json.loads(r[0]) for r in rows]
 
 


### PR DESCRIPTION
## Summary
- wrap sqlite3 connections in context managers
- rely on automatic commit/close
- verify database operations work

## Testing
- `python3 scripts/collect_and_visualize.py`
- `python3 - <<'PY'
import server
server.init_db()
server.load_data()
print('count', len(server.get_hosts()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684143072408832ca10e61802bf2db0e