### PR TITLE
Add basic logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ The API listens on port 5000 by default and serves host data from the
 `results` directory using a lightweight SQLite database. Be sure to run the
 helper script at least once so that the `results` directory is populated.
 
+### Logging
+Both the helper script and the Flask API use Python's `logging` module. Set
+the `LOG_LEVEL` environment variable to change verbosity, for example:
+
+```bash
+LOG_LEVEL=DEBUG python3 scripts/collect_and_visualize.py
+```
+
 ## Docker
 
 Build the image:

--- a/scripts/collect_and_visualize.py
+++ b/scripts/collect_and_visualize.py
@@ -7,6 +7,11 @@ import shutil
 from pathlib import Path
 from jinja2 import Template
 import argparse
+import logging
+
+level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, level_name, logging.INFO))
+logger = logging.getLogger(__name__)
 
 DEFAULT_NGINX_PORT = 8080
 
@@ -40,7 +45,7 @@ def run_playbook():
             str(PLAYBOOK)
         ], check=True, env=env)
     else:
-        print("ansible-playbook not found, collecting local facts only")
+        logger.info("ansible-playbook not found, collecting local facts only")
         collect_local_facts()
 
 
@@ -147,7 +152,7 @@ def generate_site(hosts):
 
     save_to_db(hosts)
 
-    print(f"Report written to {output_file}")
+    logger.info("Report written to %s", output_file)
 
 
 def generate_nginx_config(port=DEFAULT_NGINX_PORT):
@@ -171,7 +176,7 @@ def start_nginx(config_path):
             "daemon off;",
         ], check=True)
     except FileNotFoundError:
-        print("nginx is not installed. Please install nginx to serve the site.")
+        logger.warning("nginx is not installed. Please install nginx to serve the site.")
 
 
 def main():
@@ -188,8 +193,8 @@ def main():
     hosts = load_results()
     generate_site(hosts)
     cfg = generate_nginx_config(port=args.port)
-    print(f"nginx configuration written to {cfg}")
-    print(f"Serving results on http://localhost:{args.port}")
+    logger.info("nginx configuration written to %s", cfg)
+    logger.info("Serving results on http://localhost:%s", args.port)
     start_nginx(cfg)
 
 

--- a/server.py
+++ b/server.py
@@ -2,6 +2,12 @@ import json
 import sqlite3
 from pathlib import Path
 from flask import Flask, jsonify, send_from_directory
+import os
+import logging
+
+level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, level_name, logging.INFO))
+logger = logging.getLogger(__name__)
 
 BASE_DIR = Path(__file__).resolve().parent
 RESULTS_DIR = BASE_DIR / 'results'
@@ -69,4 +75,5 @@ def index():
 if __name__ == '__main__':
     init_db()
     load_data()
+    logger.info('Starting Flask server on port %s', 5000)
     app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add logger setup to helper script and Flask server
- log key events instead of using `print`
- document how to change log level

## Testing
- `python3 -m py_compile scripts/collect_and_visualize.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_684146494e1c832caafff304c7a3a884