### PR TITLE
Добавил графики CPU и памяти

### DIFF
--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -7,6 +7,12 @@
     <script crossorigin src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+      .chart-container canvas {
+        width: 100% !important;
+      }
+    </style>
 </head>
 <body>
     <div class="container my-4" id="root"></div>
@@ -26,6 +32,8 @@
       const [cpuFilter, setCpuFilter] = React.useState('');
       const [sortKey, setSortKey] = React.useState('hostname');
       const [sortDir, setSortDir] = React.useState('asc');
+      const cpuChartRef = React.useRef(null);
+      const memChartRef = React.useRef(null);
 
       const load = React.useCallback(() => {
         fetchData(search, sortKey, sortDir).then(setData);
@@ -52,6 +60,69 @@
           cpuFilter ? parseFloat(h.cpu_load) <= parseFloat(cpuFilter) : true
         );
 
+      React.useEffect(() => {
+        if (!window.Chart) return;
+        const labels = filtered.map(h => h.hostname);
+        const cpuData = filtered.map(h => parseFloat(String(h.cpu_load).split(' ')[0]) || 0);
+        const memData = filtered.map(h => {
+          const m = String(h.memory).match(/Mem:\s+(\d+)\s+(\d+)/);
+          if (m) {
+            const total = parseFloat(m[1]);
+            const used = parseFloat(m[2]);
+            return total ? (used / total * 100).toFixed(2) : 0;
+          }
+          const parts = String(h.memory).trim().split(/\s+/);
+          if (parts.length >= 3) {
+            const total = parseFloat(parts[1]);
+            const used = parseFloat(parts[2]);
+            return total ? (used / total * 100).toFixed(2) : 0;
+          }
+          return 0;
+        });
+
+        const cpuCtx = document.getElementById('cpuChart');
+        const memCtx = document.getElementById('memChart');
+
+        if (cpuChartRef.current) cpuChartRef.current.destroy();
+        if (memChartRef.current) memChartRef.current.destroy();
+
+        cpuChartRef.current = new Chart(cpuCtx, {
+          type: 'bar',
+          data: {
+            labels,
+            datasets: [{
+              label: 'CPU Load',
+              data: cpuData,
+              backgroundColor: 'rgba(54, 162, 235, 0.6)'
+            }]
+          },
+          options: {
+            responsive: true,
+            scales: {
+              y: { beginAtZero: true }
+            }
+          }
+        });
+
+        memChartRef.current = new Chart(memCtx, {
+          type: 'bar',
+          data: {
+            labels,
+            datasets: [{
+              label: 'Memory Usage %',
+              data: memData,
+              backgroundColor: 'rgba(255, 99, 132, 0.6)'
+            }]
+          },
+          options: {
+            responsive: true,
+            scales: {
+              y: { beginAtZero: true, max: 100 }
+            }
+          }
+        });
+      }, [filtered]);
+
       return (
         <div>
           <h1 class="mb-4">Collected System Facts</h1>
@@ -73,34 +144,42 @@
               />
             </div>
           </div>
-          <table class="table table-striped table-bordered">
-            <thead class="table-light">
-              <tr>
-                <th onClick={() => handleSort('hostname')}>Hostname</th>
-                <th onClick={() => handleSort('cpu_load')}>CPU Load</th>
-                <th onClick={() => handleSort('memory')}>Memory</th>
-                <th onClick={() => handleSort('disk')}>Disk</th>
-                <th>Users</th>
-                <th>Listening Ports</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map((h, i) => (
-                <tr key={i}>
-                  <td>{h.hostname}</td>
-                  <td>{h.cpu_load}</td>
-                  <td>{h.memory}</td>
-                  <td>{h.disk}</td>
-                  <td>
-                    <ul class="mb-0">{h.users.map((u, j) => <li key={j}>{u}</li>)}</ul>
-                  </td>
-                  <td>
-                    <ul class="mb-0">{h.ports.map((p, j) => <li key={j}>{p}</li>)}</ul>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <div class="row">
+            <div class="col-lg-8">
+              <table class="table table-striped table-bordered">
+                <thead class="table-light">
+                  <tr>
+                    <th onClick={() => handleSort('hostname')}>Hostname</th>
+                    <th onClick={() => handleSort('cpu_load')}>CPU Load</th>
+                    <th onClick={() => handleSort('memory')}>Memory</th>
+                    <th onClick={() => handleSort('disk')}>Disk</th>
+                    <th>Users</th>
+                    <th>Listening Ports</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((h, i) => (
+                    <tr key={i}>
+                      <td>{h.hostname}</td>
+                      <td>{h.cpu_load}</td>
+                      <td>{h.memory}</td>
+                      <td>{h.disk}</td>
+                      <td>
+                        <ul class="mb-0">{h.users.map((u, j) => <li key={j}>{u}</li>)}</ul>
+                      </td>
+                      <td>
+                        <ul class="mb-0">{h.ports.map((p, j) => <li key={j}>{p}</li>)}</ul>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div class="col-lg-4 chart-container">
+              <canvas id="cpuChart" height="200"></canvas>
+              <canvas id="memChart" height="200" class="mt-4"></canvas>
+            </div>
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- connect Chart.js and layout support for graphs
- render CPU load and memory usage charts from API data
- place graphs beside the table using Bootstrap grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68414a402e78832c89c02216ebb5cabd