### PR TITLE
Add network and sensor metrics

### DIFF
--- a/ansible/collect_facts.yml
+++ b/ansible/collect_facts.yml
@@ -30,6 +30,15 @@
       command: cat /proc/loadavg
       register: cpu_load
 
+    - name: Get network stats
+      command: cat /proc/net/dev
+      register: net_stats
+
+    - name: Get temperature sensors
+      command: sensors
+      register: sensor_data
+      ignore_errors: yes
+
     - name: Save facts to JSON
       copy:
         dest: "{{ output_dir }}/facts_{{ inventory_hostname }}.json"
@@ -40,6 +49,8 @@
             "ports": {{ port_list.stdout_lines | to_json }},
             "disk": {{ disk_usage.stdout | to_json }},
             "memory": {{ memory_info.stdout | to_json }},
-            "cpu_load": {{ cpu_load.stdout | to_json }}
+            "cpu_load": {{ cpu_load.stdout | to_json }},
+            "net": {{ net_stats.stdout_lines | to_json }},
+            "sensors": {{ sensor_data.stdout_lines | to_json }}
           }
       delegate_to: localhost

--- a/scripts/collect_and_visualize.py
+++ b/scripts/collect_and_visualize.py
@@ -69,6 +69,14 @@ def collect_local_facts():
     ).strip()
     cpu_load = subprocess.check_output(["cat", "/proc/loadavg"], text=True).strip()
 
+    with open("/proc/net/dev", "r") as f:
+        net_stats = f.read().splitlines()
+
+    try:
+        sensors_out = subprocess.check_output(["sensors"], text=True).splitlines()
+    except FileNotFoundError:
+        sensors_out = []
+
     RESULTS_DIR.mkdir(exist_ok=True)
     data = {
         "hostname": hostname,
@@ -77,6 +85,8 @@ def collect_local_facts():
         "disk": disk,
         "memory": memory,
         "cpu_load": cpu_load,
+        "net": net_stats,
+        "sensors": sensors_out,
     }
     with open(RESULTS_DIR / f"facts_{hostname}.json", "w") as f:
         json.dump(data, f, indent=2)

--- a/server.py
+++ b/server.py
@@ -54,7 +54,7 @@ def get_hosts(search=None, sort=None, order="asc"):
             params.append(f"%{search}%")
 
         if sort:
-            allowed = {"hostname", "cpu_load", "memory", "disk"}
+            allowed = {"hostname", "cpu_load", "memory", "disk", "net", "sensors"}
             if sort == "hostname":
                 order_field = "hostname"
             elif sort in allowed:

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -155,6 +155,8 @@
                     <th onClick={() => handleSort('disk')}>Disk</th>
                     <th>Users</th>
                     <th>Listening Ports</th>
+                    <th>Network</th>
+                    <th>Sensors</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -169,6 +171,12 @@
                       </td>
                       <td>
                         <ul class="mb-0">{h.ports.map((p, j) => <li key={j}>{p}</li>)}</ul>
+                      </td>
+                      <td>
+                        <ul class="mb-0">{h.net.map((n, j) => <li key={j}>{n}</li>)}</ul>
+                      </td>
+                      <td>
+                        <ul class="mb-0">{h.sensors.map((s, j) => <li key={j}>{s}</li>)}</ul>
                       </td>
                     </tr>
                   ))}


### PR DESCRIPTION
## Summary
- extend Ansible playbook to gather `/proc/net/dev` and sensor data
- collect same metrics in local Python fallback
- display new metrics in HTML report
- allow sorting by network and sensor data in the API

## Testing
- `python3 -m py_compile scripts/collect_and_visualize.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_68414be235d8832c99b1cc07a6b0d6d2