### PR TITLE
Improve README, add tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -8,17 +8,22 @@ Python helper script located in the `scripts/` directory runs the playbook and
 generates a web page using templates stored in `templates/`.
 
 ## Requirements
-- Python 3
+- Python 3.11
 - Ansible
 - Jinja2 (installed automatically with Ansible)
+- Flask
+- pytest (for running the tests)
+- docker and docker-compose
 - nginx (optional, installed automatically by `setup.sh`)
 - See `requirements.txt` for the full Python dependencies
 
 ## Setup
-Run the provided helper script to automatically install the necessary packages
-and Python requirements:
+Run the provided helper script to automatically install the system packages and
+Python requirements. It is recommended to create a virtual environment first:
 
 ```bash
+python3 -m venv venv
+source venv/bin/activate
 ./setup.sh
 pip3 install -r requirements.txt
 ```
@@ -62,6 +67,17 @@ the `LOG_LEVEL` environment variable to change verbosity, for example:
 LOG_LEVEL=DEBUG python3 scripts/collect_and_visualize.py
 ```
 
+## Tests
+Install development dependencies and run the unit tests with `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+The CI workflow located in `.github/workflows/ci.yml` automatically executes
+these tests on every push and pull request.
+
 ## Docker
 
 Build the image:
@@ -88,11 +104,26 @@ docker run -p 5000:5000 -v $(pwd)/results:/app/results autocfg
 ### Using docker-compose
 
 A sample `docker-compose.yml` is provided to launch the Flask API together with
-an nginx container that serves the static site and proxies API requests. Start
-both services with:
+an nginx container that serves the static site and proxies API requests. The
+`flask` service is built from the local `Dockerfile` and shares the `results`
+directory with the `nginx` container.
+
+Start both services with:
 
 ```bash
 docker-compose up --build
 ```
 
 The site will be available on [http://localhost:8080](http://localhost:8080).
+
+### Publishing the image
+
+To publish the API image to a registry like Docker Hub run:
+
+```bash
+docker build -t yourname/autocfg:latest .
+docker push yourname/autocfg:latest
+```
+
+The compose file can then reference the pushed tag instead of building the
+image locally.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ansible
 Jinja2
 Flask
+pytest

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import collect_and_visualize as cav
+import sys
+
+
+def test_parse_args_defaults(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['prog'])
+    args = cav.parse_args()
+    assert args.output_dir == str(cav.DEFAULT_RESULTS_DIR)
+    assert args.port == cav.DEFAULT_NGINX_PORT

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import server
+from flask import Flask
+
+
+def test_index_without_file(tmp_path):
+    original_dir = server.RESULTS_DIR
+    server.RESULTS_DIR = tmp_path
+    app: Flask = server.app
+    with app.test_client() as client:
+        resp = client.get('/')
+        assert resp.status_code == 200
+        assert b'Flask server is running' in resp.data
+    server.RESULTS_DIR = original_dir


### PR DESCRIPTION
## Summary
- document dependencies, pytest usage and docker-compose
- recommend using a virtual environment
- explain publishing the Docker image
- include pytest in requirements
- add GitHub Actions workflow
- add simple tests for the server and CLI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414d081a54832c8b8eee51ae68dbe0