### PR TITLE
Add local run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ Start both services with:
 docker-compose up --build
 ```
 
+Alternatively you can run the helper script `run_local.sh` which collects
+the host data and launches the compose stack in one step:
+
+```bash
+./run_local.sh
+```
+
 The site will be available on [http://localhost:8080](http://localhost:8080).
 
 ### Publishing the image

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Collect host data and launch the application using docker-compose
+set -e
+
+python3 scripts/collect_and_visualize.py \
+  --output-dir results \
+  --inventory ansible/hosts.ini \
+  --skip-nginx
+
+# build and start the compose stack
+exec docker-compose up --build

--- a/scripts/collect_and_visualize.py
+++ b/scripts/collect_and_visualize.py
@@ -146,6 +146,11 @@ def parse_args():
         default=DEFAULT_NGINX_PORT,
         help="port for the temporary nginx server",
     )
+    parser.add_argument(
+        "--skip-nginx",
+        action="store_true",
+        help="collect data only and do not launch nginx",
+    )
     return parser.parse_args()
 
 
@@ -204,6 +209,9 @@ def main():
     generate_site(hosts)
     cfg = generate_nginx_config(port=args.port)
     logger.info("nginx configuration written to %s", cfg)
+    if args.skip_nginx:
+        logger.info("Skipping nginx startup")
+        return
     logger.info("Serving results on http://localhost:%s", args.port)
     start_nginx(cfg)
 


### PR DESCRIPTION
## Summary
- support skipping nginx in `collect_and_visualize.py`
- add `run_local.sh` for quick local deployment via docker-compose
- document how to use the helper script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684150c926d0832ca7b199933f4aaa48