### PR TITLE
Add linting tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run black check
+        run: black --check .
+      - name: Run flake8
+        run: flake8
       - name: Run tests
         run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ ansible
 Jinja2
 Flask
 pytest
+black
+flake8

--- a/scripts/collect_and_visualize.py
+++ b/scripts/collect_and_visualize.py
@@ -38,12 +38,11 @@ def run_playbook():
     if shutil.which("ansible-playbook"):
         env = os.environ.copy()
         env["OUTPUT_DIR"] = str(RESULTS_DIR)
-        subprocess.run([
-            "ansible-playbook",
-            "-i",
-            str(INVENTORY),
-            str(PLAYBOOK)
-        ], check=True, env=env)
+        subprocess.run(
+            ["ansible-playbook", "-i", str(INVENTORY), str(PLAYBOOK)],
+            check=True,
+            env=env,
+        )
     else:
         logger.info("ansible-playbook not found, collecting local facts only")
         collect_local_facts()
@@ -181,17 +180,22 @@ def generate_nginx_config(port=DEFAULT_NGINX_PORT):
 def start_nginx(config_path):
     """Start nginx using the generated config if available."""
     try:
-        subprocess.run([
-            "nginx",
-            "-c",
-            str(config_path),
-            "-p",
-            str(RESULTS_DIR),
-            "-g",
-            "daemon off;",
-        ], check=True)
+        subprocess.run(
+            [
+                "nginx",
+                "-c",
+                str(config_path),
+                "-p",
+                str(RESULTS_DIR),
+                "-g",
+                "daemon off;",
+            ],
+            check=True,
+        )
     except FileNotFoundError:
-        logger.warning("nginx is not installed. Please install nginx to serve the site.")
+        logger.warning(
+            "nginx is not installed. Please install nginx to serve the site."
+        )
 
 
 def main():

--- a/server.py
+++ b/server.py
@@ -10,9 +10,9 @@ logging.basicConfig(level=getattr(logging, level_name, logging.INFO))
 logger = logging.getLogger(__name__)
 
 BASE_DIR = Path(__file__).resolve().parent
-RESULTS_DIR = BASE_DIR / 'results'
-DB_PATH = RESULTS_DIR / 'data.db'
-DATA_JSON = RESULTS_DIR / 'data.json'
+RESULTS_DIR = BASE_DIR / "results"
+DB_PATH = RESULTS_DIR / "data.db"
+DATA_JSON = RESULTS_DIR / "data.json"
 
 app = Flask(__name__)
 
@@ -74,7 +74,7 @@ def get_hosts(search=None, sort=None, order="asc"):
     return [json.loads(r[0]) for r in rows]
 
 
-@app.route('/api/hosts')
+@app.route("/api/hosts")
 def hosts():
     search = request.args.get("search")
     sort = request.args.get("sort")
@@ -83,16 +83,16 @@ def hosts():
     return jsonify(hosts_list)
 
 
-@app.route('/')
+@app.route("/")
 def index():
-    index_file = RESULTS_DIR / 'index.html'
+    index_file = RESULTS_DIR / "index.html"
     if index_file.exists():
-        return send_from_directory(RESULTS_DIR, 'index.html')
-    return 'Flask server is running. Use /api/hosts to get data.'
+        return send_from_directory(RESULTS_DIR, "index.html")
+    return "Flask server is running. Use /api/hosts to get data."
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     init_db()
     load_data()
-    logger.info('Starting Flask server on port %s', 5000)
-    app.run(host='0.0.0.0', port=5000)
+    logger.info("Starting Flask server on port %s", 5000)
+    app.run(host="0.0.0.0", port=5000)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503, E402
+
+[tool:pytest]
+addopts = -ra

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from scripts import collect_and_visualize as cav
@@ -7,7 +8,7 @@ import sys
 
 
 def test_parse_args_defaults(monkeypatch):
-    monkeypatch.setattr(sys, 'argv', ['prog'])
+    monkeypatch.setattr(sys, "argv", ["prog"])
     args = cav.parse_args()
     assert args.output_dir == str(cav.DEFAULT_RESULTS_DIR)
     assert args.port == cav.DEFAULT_NGINX_PORT

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import server
@@ -11,7 +12,7 @@ def test_index_without_file(tmp_path):
     server.RESULTS_DIR = tmp_path
     app: Flask = server.app
     with app.test_client() as client:
-        resp = client.get('/')
+        resp = client.get("/")
         assert resp.status_code == 200
-        assert b'Flask server is running' in resp.data
+        assert b"Flask server is running" in resp.data
     server.RESULTS_DIR = original_dir


### PR DESCRIPTION
## Summary
- add black and flake8 dependencies
- configure flake8 rules
- run black and flake8 in CI
- provide a matching pre-commit setup
- format code with black

## Testing
- `pre-commit run --files server.py scripts/collect_and_visualize.py tests/test_collect.py tests/test_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684157cba0d8832c9fbb689167ea0114