### PR TITLE
Add API token auth to hosts endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ the `LOG_LEVEL` environment variable to change verbosity, for example:
 LOG_LEVEL=DEBUG python3 scripts/collect_and_visualize.py
 ```
 
+### API Token
+Set the `API_TOKEN` environment variable to protect the `/api/hosts` endpoint.
+Requests must include an `Authorization` header with the same token:
+
+```bash
+API_TOKEN=secret python3 server.py
+```
+
+Example request:
+
+```bash
+curl -H "Authorization: Bearer secret" http://localhost:5000/api/hosts
+```
+
 ## Tests
 Install development dependencies and run the unit tests with `pytest`:
 

--- a/server.py
+++ b/server.py
@@ -9,6 +9,9 @@ level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(level=getattr(logging, level_name, logging.INFO))
 logger = logging.getLogger(__name__)
 
+# Authentication token for API requests
+API_TOKEN = os.environ.get("API_TOKEN")
+
 BASE_DIR = Path(__file__).resolve().parent
 RESULTS_DIR = BASE_DIR / "results"
 DB_PATH = RESULTS_DIR / "data.db"
@@ -76,6 +79,9 @@ def get_hosts(search=None, sort=None, order="asc"):
 
 @app.route("/api/hosts")
 def hosts():
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {API_TOKEN}":
+        return "", 401
     search = request.args.get("search")
     sort = request.args.get("sort")
     order = request.args.get("order", "asc")

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import server
+
+
+def _setup(tmp_path, monkeypatch):
+    original_db = server.DB_PATH
+    server.DB_PATH = tmp_path / "data.db"
+    server.init_db()
+    monkeypatch.setattr(server, "API_TOKEN", "secret")
+    return original_db
+
+
+def test_hosts_requires_token(tmp_path, monkeypatch):
+    original_db = _setup(tmp_path, monkeypatch)
+    app = server.app
+    with app.test_client() as client:
+        resp = client.get("/api/hosts")
+        assert resp.status_code == 401
+    server.DB_PATH = original_db
+
+
+def test_hosts_invalid_token(tmp_path, monkeypatch):
+    original_db = _setup(tmp_path, monkeypatch)
+    app = server.app
+    with app.test_client() as client:
+        resp = client.get("/api/hosts", headers={"Authorization": "Bearer wrong"})
+        assert resp.status_code == 401
+    server.DB_PATH = original_db
+
+
+def test_hosts_valid_token(tmp_path, monkeypatch):
+    original_db = _setup(tmp_path, monkeypatch)
+    app = server.app
+    with app.test_client() as client:
+        resp = client.get("/api/hosts", headers={"Authorization": "Bearer secret"})
+        assert resp.status_code == 200
+    server.DB_PATH = original_db


### PR DESCRIPTION
## Summary
- read token from `API_TOKEN`
- check `Authorization` header for `/api/hosts`
- document token usage in README
- test host endpoint authentication

## Testing
- `black server.py tests/test_server_auth.py`
- `flake8 server.py tests/test_server_auth.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841593a6938832cbf51b8369f83e88a