### PR TITLE
Add reload API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,25 @@ LOG_LEVEL=DEBUG python3 scripts/collect_and_visualize.py
 ```
 
 ### API Token
-Set the `API_TOKEN` environment variable to protect the `/api/hosts` endpoint.
-Requests must include an `Authorization` header with the same token:
+Set the `API_TOKEN` environment variable to protect the `/api/hosts` and
+`/api/reload` endpoints. Requests must include an `Authorization` header with
+the same token:
 
 ```bash
 API_TOKEN=secret python3 server.py
 ```
 
-Example request:
+Example request for listing hosts:
 
 ```bash
 curl -H "Authorization: Bearer secret" http://localhost:5000/api/hosts
+```
+
+Reload the database after running the helper script:
+
+```bash
+curl -X POST -H "Authorization: Bearer secret" \
+     http://localhost:5000/api/reload
 ```
 
 ## Tests

--- a/server.py
+++ b/server.py
@@ -31,6 +31,7 @@ def init_db():
 
 
 def load_data():
+    """Load hosts from ``DATA_JSON`` into the SQLite database."""
     if DATA_JSON.exists():
         with open(DATA_JSON) as f:
             hosts = json.load(f)
@@ -90,12 +91,25 @@ def hosts():
     return jsonify(hosts_list)
 
 
+@app.route("/api/reload", methods=["POST"])
+def reload_data_endpoint():
+    """Reload host information from ``DATA_JSON``. Requires API token."""
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {API_TOKEN}":
+        return "", 401
+    load_data()
+    return jsonify({"status": "reloaded"})
+
+
 @app.route("/")
 def index():
     index_file = RESULTS_DIR / "index.html"
     if index_file.exists():
         return send_from_directory(RESULTS_DIR, "index.html")
-    return "Flask server is running. Use /api/hosts to get data."
+    return (
+        "Flask server is running. Use /api/hosts to get data. "
+        "POST /api/reload to refresh."
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_server_reload.py
+++ b/tests/test_server_reload.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+import json
+import sqlite3
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import server
+
+
+def _setup(tmp_path, monkeypatch):
+    data = [{"hostname": "alpha"}]
+    data_file = tmp_path / "data.json"
+    with open(data_file, "w") as f:
+        json.dump(data, f)
+    original_db = server.DB_PATH
+    original_json = server.DATA_JSON
+    original_results = server.RESULTS_DIR
+    server.DB_PATH = tmp_path / "data.db"
+    server.DATA_JSON = data_file
+    server.RESULTS_DIR = tmp_path
+    server.init_db()
+    monkeypatch.setattr(server, "API_TOKEN", "secret")
+    return original_db, original_json, original_results
+
+
+def _teardown(originals):
+    db, data_json, results_dir = originals
+    server.DB_PATH = db
+    server.DATA_JSON = data_json
+    server.RESULTS_DIR = results_dir
+
+
+def test_reload_requires_token(tmp_path, monkeypatch):
+    originals = _setup(tmp_path, monkeypatch)
+    app = server.app
+    with app.test_client() as client:
+        resp = client.post("/api/reload")
+        assert resp.status_code == 401
+    _teardown(originals)
+
+
+def test_reload_invalid_token(tmp_path, monkeypatch):
+    originals = _setup(tmp_path, monkeypatch)
+    app = server.app
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/reload", headers={"Authorization": "Bearer wrong"}
+        )
+        assert resp.status_code == 401
+    _teardown(originals)
+
+
+def test_reload_valid_token(tmp_path, monkeypatch):
+    originals = _setup(tmp_path, monkeypatch)
+    app = server.app
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/reload", headers={"Authorization": "Bearer secret"}
+        )
+        assert resp.status_code == 200
+        assert resp.get_json() == {"status": "reloaded"}
+    hosts = server.get_hosts()
+    assert hosts[0]["hostname"] == "alpha"
+    _teardown(originals)


### PR DESCRIPTION
## Summary
- allow reloading data from `data.json` via `/api/reload`
- document new endpoint and authentication in README
- improve `load_data` docstring and update index message
- test token protection of `/api/reload`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415c5e9060832c91edd19aa3f6e0e7