### PR TITLE
Fix Docker entrypoint and helper script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 EXPOSE 5000
-CMD ["python", "server.py"]
+CMD ["python", "-m", "autoconfig.server"]

--- a/run_local.sh
+++ b/run_local.sh
@@ -2,7 +2,7 @@
 # Collect host data and launch the application using docker-compose
 set -e
 
-python3 scripts/collect_and_visualize.py \
+python3 -m autoconfig.collect_and_visualize \
   --output-dir results \
   --inventory ansible/hosts.ini \
   --skip-nginx


### PR DESCRIPTION
## Summary
- fix Dockerfile CMD to run server module
- update helper script path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416f9a57d4832c85d18f6351c76790