### PR TITLE
Add Sphinx docs and GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: docs
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt sphinx
+      - name: Build docs
+        run: sphinx-build -b html docs/source docs/build/html
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs/build/html
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 results/
 node_modules/
 templates/dist/
+docs/build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,0 +1,36 @@
+Command Line Interface
+======================
+
+The project provides two entry points: ``collect_and_visualize`` and ``server``.
+
+Run the helper script to collect system facts and generate a small report:
+
+.. code-block:: bash
+
+   python3 -m autoconfig.collect_and_visualize \
+     --output-dir results \
+     --inventory ansible/hosts.ini \
+     --port 8080
+
+Additional options:
+
+``--hosts``
+    Comma separated list of hosts to process in parallel. If Ansible is not
+    available the script will collect facts over SSH.
+
+``--skip-nginx``
+    Collect data only and do not launch nginx.
+
+Run the Flask API directly using ``server``:
+
+.. code-block:: bash
+
+   python3 -m autoconfig.server --port 8000 --results-dir results
+
+Environment variables:
+
+``LOG_LEVEL``
+    Adjust verbosity of both commands.
+
+``API_TOKEN``
+    Token required for accessing protected API endpoints.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,34 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+project = "AutoConfig"
+copyright = "2025, AutoConfig Developers"
+author = "AutoConfig Developers"
+
+version = "0.1.0"
+release = "0.1.0"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinx.ext.autodoc"]
+
+templates_path = ["_templates"]
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,0 +1,11 @@
+Examples
+========
+
+Simple example showing how to query the API for the list of hosts using
+``curl`` with an authentication token:
+
+.. code-block:: bash
+
+   API_TOKEN=secret
+   curl -H "Authorization: Bearer $API_TOKEN" \
+        http://localhost:5000/api/hosts

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,17 @@
+.. AutoConfig documentation master file, created by
+   sphinx-quickstart on Thu Jun  5 10:47:14 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+AutoConfig documentation
+========================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   setup
+   cli
+   rest_api
+   tests
+   examples

--- a/docs/source/rest_api.rst
+++ b/docs/source/rest_api.rst
@@ -1,0 +1,13 @@
+REST API
+========
+
+The Flask application exposes a small JSON API.
+
+``/api/hosts``
+    Return host information. Supports optional query parameters ``search``,
+    ``sort`` and ``order``. Requires an ``Authorization`` header containing the
+    ``API_TOKEN`` value.
+
+``/api/reload``
+    POST endpoint that reloads data from ``results/data.json`` into the
+    database. Also protected by ``API_TOKEN``.

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -1,0 +1,13 @@
+Environment Setup
+=================
+
+Follow these steps to prepare a local development environment.
+
+.. code-block:: bash
+
+   python3 -m venv venv
+   source venv/bin/activate
+   ./setup.sh
+   pip install -r requirements.txt
+   npm install
+   npm run build

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -1,0 +1,9 @@
+Running Tests
+=============
+
+Install development dependencies and execute the unit tests using ``pytest``.
+
+.. code-block:: bash
+
+   pip install -r requirements.txt
+   pytest


### PR DESCRIPTION
## Summary
- generate Sphinx documentation scaffold under `docs/`
- document CLI usage, REST API, setup, tests and code examples
- ignore built documentation
- add workflow to build and deploy docs to GitHub Pages

## Testing
- `pip install -r requirements.txt`
- `black --check .`
- `flake8`
- `pytest`
- `sphinx-build -b html docs/source docs/build/html`


------
https://chatgpt.com/codex/tasks/task_e_6841758160e4832cbe681f2c2338458c