### PR TITLE
Add template CRUD API

### DIFF
--- a/autoconfig/server.py
+++ b/autoconfig/server.py
@@ -5,6 +5,9 @@ from flask import Flask, jsonify, send_from_directory, request
 import os
 import logging
 import argparse
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime
 
 level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(level=getattr(logging, level_name, logging.INFO))
@@ -21,6 +24,22 @@ RESULTS_DIR = BASE_DIR / "results"
 DB_PATH = RESULTS_DIR / "data.db"
 DATA_JSON = RESULTS_DIR / "data.json"
 
+
+@dataclass
+class Template:
+    id: str
+    name: str
+    description: str | None
+    version: int
+    config: dict
+    created_at: str
+    updated_at: str
+    active: int = 0
+
+    def to_dict(self):
+        return asdict(self)
+
+
 app = Flask(__name__)
 
 
@@ -30,6 +49,25 @@ def init_db():
         cur = conn.cursor()
         cur.execute(
             "CREATE TABLE IF NOT EXISTS hosts (hostname TEXT PRIMARY KEY, data TEXT)"
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS templates (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT,
+                version INTEGER NOT NULL,
+                config TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                active INTEGER DEFAULT 0,
+                UNIQUE(name, version)
+            )
+            """
+        )
+        cur.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_templates_name_version "
+            "ON templates(name, version)"
         )
 
 
@@ -48,6 +86,113 @@ def load_data():
                 "INSERT OR REPLACE INTO hosts(hostname, data) VALUES(?, ?)",
                 (h.get("hostname"), json.dumps(h)),
             )
+
+
+def _now() -> str:
+    return datetime.utcnow().isoformat()
+
+
+def create_template(name: str, description: str | None, config: dict) -> Template:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT MAX(version) FROM templates WHERE name = ?", (name,))
+        row = cur.fetchone()
+        version = (row[0] or 0) + 1
+        tid = str(uuid.uuid4())
+        ts = _now()
+        cur.execute(
+            (
+                "INSERT INTO templates(id, name, description, version, config, "
+                "created_at, updated_at) VALUES(?,?,?,?,?,?,?)"
+            ),
+            (tid, name, description, version, json.dumps(config), ts, ts),
+        )
+        conn.commit()
+    return Template(tid, name, description, version, config, ts, ts)
+
+
+def list_latest_templates(limit: int = 100, offset: int = 0) -> list[Template]:
+    query = """
+    SELECT t1.* FROM templates t1
+    JOIN (SELECT name, MAX(version) AS ver FROM templates GROUP BY name) t2
+      ON t1.name = t2.name AND t1.version = t2.ver
+    ORDER BY t1.name LIMIT ? OFFSET ?
+    """
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(query, (limit, offset))
+        rows = cur.fetchall()
+    return [
+        Template(
+            r[0],
+            r[1],
+            r[2],
+            r[3],
+            json.loads(r[4]),
+            r[5],
+            r[6],
+            r[7],
+        )
+        for r in rows
+    ]
+
+
+def get_template(template_id: str) -> Template | None:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM templates WHERE id = ?", (template_id,))
+        row = cur.fetchone()
+    if not row:
+        return None
+    return Template(
+        row[0],
+        row[1],
+        row[2],
+        row[3],
+        json.loads(row[4]),
+        row[5],
+        row[6],
+        row[7],
+    )
+
+
+def update_template(
+    template_id: str, description: str | None, config: dict | None
+) -> Template | None:
+    tpl = get_template(template_id)
+    if not tpl:
+        return None
+    new_desc = description if description is not None else tpl.description
+    new_config = config if config is not None else tpl.config
+    ts = _now()
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            (
+                "UPDATE templates SET description = ?, config = ?, updated_at = ? "
+                "WHERE id = ?"
+            ),
+            (new_desc, json.dumps(new_config), ts, template_id),
+        )
+        conn.commit()
+    return Template(
+        tpl.id,
+        tpl.name,
+        new_desc,
+        tpl.version,
+        new_config,
+        tpl.created_at,
+        ts,
+        tpl.active,
+    )
+
+
+def delete_template(template_id: str) -> bool:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.cursor()
+        cur.execute("DELETE FROM templates WHERE id = ?", (template_id,))
+        conn.commit()
+        return cur.rowcount > 0
 
 
 def get_hosts(search=None, sort=None, order="asc"):
@@ -92,6 +237,75 @@ def hosts():
     order = request.args.get("order", "asc")
     hosts_list = get_hosts(search=search, sort=sort, order=order)
     return jsonify(hosts_list)
+
+
+@app.route("/api/v1/templates", methods=["POST"])
+def create_template_endpoint():
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {API_TOKEN}":
+        return "", 401
+    data = request.get_json(force=True)
+    name = data.get("name")
+    if not name:
+        return jsonify({"error": "name required"}), 400
+    description = data.get("description")
+    config = data.get("config")
+    if not isinstance(config, dict):
+        return jsonify({"error": "config must be object"}), 400
+    tpl = create_template(name, description, config)
+    return jsonify(tpl.to_dict()), 201
+
+
+@app.route("/api/v1/templates", methods=["GET"])
+def list_templates_endpoint():
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {API_TOKEN}":
+        return "", 401
+    try:
+        limit = int(request.args.get("limit", 100))
+        offset = int(request.args.get("offset", 0))
+    except ValueError:
+        return jsonify({"error": "invalid pagination"}), 400
+    templates = [t.to_dict() for t in list_latest_templates(limit, offset)]
+    return jsonify(templates)
+
+
+@app.route("/api/v1/templates/<template_id>", methods=["GET"])
+def get_template_endpoint(template_id):
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {API_TOKEN}":
+        return "", 401
+    tpl = get_template(template_id)
+    if not tpl:
+        return jsonify({"error": "Template not found"}), 404
+    return jsonify(tpl.to_dict())
+
+
+@app.route("/api/v1/templates/<template_id>", methods=["PUT"])
+def update_template_endpoint(template_id):
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {API_TOKEN}":
+        return "", 401
+    data = request.get_json(force=True)
+    description = data.get("description")
+    config = data.get("config")
+    if config is not None and not isinstance(config, dict):
+        return jsonify({"error": "config must be object"}), 400
+    tpl = update_template(template_id, description, config)
+    if not tpl:
+        return jsonify({"error": "Template not found"}), 404
+    return jsonify(tpl.to_dict())
+
+
+@app.route("/api/v1/templates/<template_id>", methods=["DELETE"])
+def delete_template_endpoint(template_id):
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {API_TOKEN}":
+        return "", 401
+    deleted = delete_template(template_id)
+    if not deleted:
+        return jsonify({"error": "Template not found"}), 404
+    return "", 204
 
 
 @app.route("/api/reload", methods=["POST"])

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from autoconfig import server
+
+
+def _setup(tmp_path, monkeypatch):
+    server.DB_PATH = tmp_path / "data.db"
+    server.RESULTS_DIR = tmp_path
+    server.init_db()
+    monkeypatch.setattr(server, "API_TOKEN", "secret")
+
+
+def test_create_and_get_template(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    app = server.app
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/v1/templates",
+            json={"name": "foo", "description": "d", "config": {"a": 1}},
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert resp.status_code == 201
+        data = resp.get_json()
+        tid = data["id"]
+        assert data["version"] == 1
+
+        resp = client.get(
+            f"/api/v1/templates/{tid}", headers={"Authorization": "Bearer secret"}
+        )
+        assert resp.status_code == 200
+        fetched = resp.get_json()
+        assert fetched["id"] == tid
+        assert fetched["version"] == 1
+
+
+def test_version_increment(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    app = server.app
+    with app.test_client() as client:
+        for i in range(2):
+            resp = client.post(
+                "/api/v1/templates",
+                json={"name": "foo", "description": "d", "config": {"a": i}},
+                headers={"Authorization": "Bearer secret"},
+            )
+            assert resp.status_code == 201
+            assert resp.get_json()["version"] == i + 1
+
+        resp = client.get(
+            "/api/v1/templates",
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert resp.status_code == 200
+        items = resp.get_json()
+        assert len(items) == 1
+        assert items[0]["version"] == 2


### PR DESCRIPTION
## Summary
- support Template records in DB
- add CRUD endpoints for templates
- test template operations

## Testing
- `flake8 .`
- `black . --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68485ab48948832c8e5427a804eb204b