### PR TITLE
Implement worker service skeleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "ansible",
     "Jinja2",
     "Flask",
+    "pika",
+    "requests",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ Flask
 pytest
 black
 flake8
+pika
+requests

--- a/src/worker/README.md
+++ b/src/worker/README.md
@@ -1,0 +1,22 @@
+# Worker Service
+
+This worker listens for simulation messages and runs scenario plugins.
+
+## Development
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run the worker in development mode:
+
+```bash
+export WORKER_BROKER_URL="amqp://guest:guest@localhost:5672/"
+python -m worker.cmd.main
+```
+
+The service exposes a health check on `http://localhost:8081/health`.

--- a/src/worker/__init__.py
+++ b/src/worker/__init__.py
@@ -1,0 +1,1 @@
+"""Worker service package."""

--- a/src/worker/cmd/main.py
+++ b/src/worker/cmd/main.py
@@ -1,0 +1,55 @@
+import logging
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import threading
+import json
+
+from worker.config import settings
+from worker.internal.broker import BrokerClient
+from worker.pkg.plugins import get_plugin
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def health_server():
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"OK")
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+    server = HTTPServer(("0.0.0.0", settings.health_port), Handler)
+    logger.info("Healthcheck on port %s", settings.health_port)
+    server.serve_forever()
+
+
+def on_message(body: bytes):
+    logger.info("Received message: %s", body)
+    try:
+        data = json.loads(body)
+        plugin_name = data.get("template_type", "noop")
+        params = data.get("params", {})
+    except Exception:
+        logger.error("Invalid message")
+        return
+    plugin_cls = get_plugin(plugin_name)
+    if not plugin_cls:
+        logger.error("Unknown plugin %s", plugin_name)
+        return
+    plugin = plugin_cls()
+    for event in plugin.start(**params):
+        logger.info("event: %s", event)
+
+
+def main():
+    threading.Thread(target=health_server, daemon=True).start()
+    broker = BrokerClient(settings.broker_url)
+    broker.subscribe("simulations.start", on_message)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/worker/config/__init__.py
+++ b/src/worker/config/__init__.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+import os
+
+
+def get_env(name: str, default: str | None = None) -> str:
+    return os.environ.get(name, default) or ""
+
+
+@dataclass
+class Settings:
+    broker_url: str = get_env("WORKER_BROKER_URL", "amqp://guest:guest@localhost:5672/")
+    health_port: int = int(get_env("WORKER_HEALTH_PORT", "8081"))
+
+
+settings = Settings()

--- a/src/worker/internal/broker.py
+++ b/src/worker/internal/broker.py
@@ -1,0 +1,35 @@
+import logging
+import time
+import pika
+
+logger = logging.getLogger(__name__)
+
+
+class BrokerClient:
+    def __init__(self, url: str):
+        self.url = url
+        self._connection = None
+
+    def connect(self):
+        while True:
+            try:
+                params = pika.URLParameters(self.url)
+                self._connection = pika.BlockingConnection(params)
+                logger.info("Connected to broker")
+                break
+            except Exception as e:
+                logger.error("Broker connection failed: %s", e)
+                time.sleep(5)
+
+    def subscribe(self, queue: str, callback):
+        if not self._connection:
+            self.connect()
+        channel = self._connection.channel()
+        channel.queue_declare(queue=queue, durable=True)
+
+        def _cb(ch, method, properties, body):
+            callback(body)
+            ch.basic_ack(delivery_tag=method.delivery_tag)
+
+        channel.basic_consume(queue, on_message_callback=_cb)
+        channel.start_consuming()

--- a/src/worker/pkg/plugins/__init__.py
+++ b/src/worker/pkg/plugins/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Dict, Type
+
+
+class ScenarioPlugin:
+    """Base class for all scenario plugins."""
+
+    def start(self, **params):
+        """Start the scenario and yield events as dictionaries."""
+        raise NotImplementedError
+
+
+_PLUGINS: Dict[str, Type[ScenarioPlugin]] = {}
+
+
+def register_plugin(name: str, cls: Type[ScenarioPlugin]) -> None:
+    _PLUGINS[name] = cls
+
+
+def get_plugin(name: str) -> Type[ScenarioPlugin] | None:
+    return _PLUGINS.get(name)
+
+# register built-in plugins
+from . import noop  # noqa: F401
+from . import ddos  # noqa: F401

--- a/src/worker/pkg/plugins/ddos.py
+++ b/src/worker/pkg/plugins/ddos.py
@@ -1,0 +1,20 @@
+import time
+import requests
+from . import ScenarioPlugin, register_plugin
+
+
+class DDoSPlugin(ScenarioPlugin):
+    def start(self, target_ip: str, duration: int = 10, rate: int = 1, **_):
+        end = time.time() + duration
+        sent = 0
+        while time.time() < end:
+            try:
+                requests.get(f"http://{target_ip}", timeout=1)
+            except Exception:
+                pass
+            sent += 1
+            yield {"progress": (sent / (duration * rate)), "timestamp": time.time()}
+            time.sleep(max(1 / rate, 0))
+
+
+register_plugin("ddos", DDoSPlugin)

--- a/src/worker/pkg/plugins/noop.py
+++ b/src/worker/pkg/plugins/noop.py
@@ -1,0 +1,12 @@
+import time
+from . import ScenarioPlugin, register_plugin
+
+
+class NoopPlugin(ScenarioPlugin):
+    def start(self, **params):
+        for i in range(3):
+            yield {"progress": i / 3, "timestamp": time.time()}
+            time.sleep(0.1)
+
+
+register_plugin("noop", NoopPlugin)

--- a/tests/test_worker_plugins.py
+++ b/tests/test_worker_plugins.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from worker.pkg.plugins import get_plugin
+
+
+def test_noop_plugin():
+    plugin_cls = get_plugin("noop")
+    assert plugin_cls is not None
+    plugin = plugin_cls()
+    events = list(plugin.start())
+    assert len(events) == 3
+    assert all("progress" in e for e in events)


### PR DESCRIPTION
## Summary
- scaffold a worker service
- add plugin architecture with noop and DDoS plugins
- provide broker client and worker CLI
- document worker usage
- include unit test for plugin registration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485caa58e4832ca2cb943fe49d04fe