### PR TITLE
Add Trivy scanning to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,13 @@ jobs:
         run: flake8
       - name: Run tests
         run: pytest
+      - name: Build Docker image
+        run: docker build -t autocfg:ci .
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@v0.12.0
+        with:
+          image-ref: autocfg:ci
+          format: table
+          ignore-unfixed: true
+          exit-code: 1
+          severity: CRITICAL,HIGH

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ pytest
 
 The CI workflow located in `.github/workflows/ci.yml` automatically executes
 these tests on every push and pull request.
+In addition, the workflow builds the Docker image and scans it with
+[Trivy](https://github.com/aquasecurity/trivy), failing the job if any
+vulnerabilities of **HIGH** or **CRITICAL** severity are detected.
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- add Trivy vulnerability scan to the CI workflow
- document the new security check in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848628c6728832ca13c399b607e6a7a